### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Orvar <orvarsegerstrom@gmail.com>"]
 categories = ["simulation"]
 description = "Brainfuck/Ook/Blub interpreter"
-homepage = "https://github.com/0rvar/anyfuck"
+repository = "https://github.com/0rvar/anyfuck"
 keywords = ["brainfuck", "interpreter", "binary"]
 license = "MIT"
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.